### PR TITLE
Bump otp-rr to 0.11.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "history": "^4.7.2",
     "is-mobile": "^0.2.2",
     "lodash.isequal": "^4.5.0",
-    "otp-react-redux": "^0.11.0",
+    "otp-react-redux": "^0.11.1",
     "prop-types": "^15.6.2",
     "react": "^15.4.2",
     "react-bootstrap": "^0.30.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5770,10 +5770,10 @@ osenv@0, osenv@^0.1.4:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
 
-otp-react-redux@^0.11.0:
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/otp-react-redux/-/otp-react-redux-0.11.0.tgz#0eff2cd1187dc37c90ba2142c45d16031a5e4daf"
-  integrity sha512-KjbM0giEMrwN4xIjgekj3KH+ukxs4DucaR798ddz7XDLIgrmEJzrIeAj6Ju+vkqDIClDoWzXp+XO9xHxaLgn5Q==
+otp-react-redux@^0.11.1:
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/otp-react-redux/-/otp-react-redux-0.11.1.tgz#863c61a5b010f41ae2d5a7555fc6c84d2866d830"
+  integrity sha512-S0jwcMfHzrbatmrLDhb428bMesAWPUQaM+NsokigGd4Y3AtOiYx4JpZVoJ7qcbOSHLK4mSycAJQeAiU5NbwukQ==
   dependencies:
     "@conveyal/lonlat" "^1.1.0"
     "@mapbox/polyline" "^0.2.0"


### PR DESCRIPTION
Bump otp-react-redux to [0.11.1](https://github.com/opentripplanner/otp-react-redux/releases/tag/v0.11.1).