### PR TITLE
Set the maximum zoom for the map

### DIFF
--- a/lib/config.yml
+++ b/lib/config.yml
@@ -93,6 +93,10 @@ map:
   initLat: 45.52
   initLon: -122.682
 
+  # closer-in zoom levels don't have any tiles that could be rendered by
+  # TriMet's tile service
+  maxZoom: 19
+
   # Base layers for default map
   baseLayers:
     - name: Streets


### PR DESCRIPTION
This sets the maximum zoom for the TriMet config such that it won't zoom in any further than where tiles are available from TriMet's tile server.