### PR TITLE
Handle custom css/html

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,6 +9,10 @@ const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin')
 const UglifyJsPlugin = require('uglifyjs-webpack-plugin')
 
 module.exports = async env => {
+  // Gather the CSS, HTML, YAML, and JS override files.
+  const CUSTOM_CSS = env && env.CUSTOM_CSS || './lib/style.scss'
+  const HTML_FILE = env && env.HTML_FILE || 'lib/index.tpl.html'
+  const YAML_CONFIG = env && env.YAML_CONFIG || './config.yml'
   // resolve the custom js file. If it is present, copy the file to a
   // temporary folder within this project so that the file will be able to
   // use the node_modules from this project
@@ -22,7 +26,7 @@ module.exports = async env => {
   return {
     entry: [
       './lib/main.js',
-      './lib/style.scss'
+      CUSTOM_CSS
     ],
     module: {
       rules: [
@@ -56,15 +60,15 @@ module.exports = async env => {
     },
     plugins: [
       new HtmlWebpackPlugin({
-        template: 'lib/index.tpl.html',
+        template: HTML_FILE,
         inject: 'body',
         filename: 'index.html'
       }),
       new MiniCssExtractPlugin(),
       new webpack.DefinePlugin({
-        // Optionally override the default config file location with some other
-        // file.
-        YAML_CONFIG: JSON.stringify(env && env.YAML_CONFIG || './config.yml'),
+        // Optionally override the default config files with some other
+        // files.
+        YAML_CONFIG: JSON.stringify(YAML_CONFIG),
         JS_CONFIG: JSON.stringify(customJsFile)
       })
     ],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,6 +8,14 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin')
 const UglifyJsPlugin = require('uglifyjs-webpack-plugin')
 
+/**
+ * Webpack can be passed a few environment variables to override the default
+ * files used to run this project. The environment variables are CUSTOM_CSS,
+ * HTML_FILE, YAML_CONFIG, and JS_CONFIG. They must each be passed in the
+ * format --env.*=/path/to/file. For example:
+ *
+ *    yarn start --env.YAML_CONFIG=/absolute/path/to/config.yml
+ */
 module.exports = async env => {
   // Gather the CSS, HTML, YAML, and JS override files.
   const CUSTOM_CSS = env && env.CUSTOM_CSS || './lib/style.scss'


### PR DESCRIPTION
This PR adds custom CSS and HTML file injection to trimet-mod-otp in order to override the default files (`lib/style.scss` and `index.tpl.html`). To override all files, do something like:

```
cp lib/style.scss lib/index.tpl.html lib/config.yml lib/config.js /tmp
yarn start --env.HTML_FILE=/tmp/index.tpl.html --env.CUSTOM_CSS=/tmp/styles.scss --env.JS_CONFIG=/tmp/config.js --env.YAML_CONFIG=/tmp/config.yml
```